### PR TITLE
Automated Changelog Entry for 6.4.0a1 on notebook-releaser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,15 @@ Use `pip install pip --upgrade` to upgrade pip. Check pip version with
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
-## 6.4.0a0
+## 6.4.0a1
 
 No merged PRs
 
 <!-- <END NEW CHANGELOG ENTRY> -->
+
+## 6.4.0a0
+
+No merged PRs
 
 ## 6.3.0
 


### PR DESCRIPTION
Automated Changelog Entry for 6.4.0a1 on notebook-releaser
Python version: 6.4.0a1
npm version: jupyter-notebook-deps: 4.0.0

After merging this PR run the "Draft Release" Workflow with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | afshin/notebook  |
| Branch  | notebook-releaser  |
| Version Spec | 6.4.0a1 |
